### PR TITLE
Fix CI "repository_app_id"

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -116,6 +116,7 @@ jobs:
                 uses: keboola/action-set-tag-developer-portal@master
                 with:
                     vendor: '${{ env.KBC_DEVELOPERPORTAL_VENDOR }}'
+                    repository_app_id: keboola.runner-config-test
                     app_id: keboola.runner-config-test-gelf
                     username: '${{ env.KBC_DEVELOPERPORTAL_USERNAME }}'
                     password: '${{ env.KBC_DEVELOPERPORTAL_PASSWORD }}'


### PR DESCRIPTION
v ECRku to je pushnutý pod `keboola.runner-config-test` takže i gelf by měl mít tenhle image.. jinak se to ukládá správně